### PR TITLE
Writing from USB host to littlefs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,5 +48,18 @@ target_sources(littlefs INTERFACE
    lib/littlefs/lfs_util.c
 )
 
+#target_compile_options(littlefs-usb PRIVATE -Werror -Wall -Wextra -Wnull-dereference)
+string(APPEND CMAKE_EXE_LINKER_FLAGS "-Wl,--print-memory-usage")
+
+
 pico_enable_stdio_usb(littlefs-usb 1)
 pico_add_extra_outputs(littlefs-usb)
+
+
+find_program(OPENOCD openocd)
+if(OPENOCD)
+  add_custom_target(flash
+    COMMAND ${OPENOCD} -f interface/cmsis-dap.cfg -f target/rp2040.cfg -c "adapter speed 5000" -c "program ${CMAKE_PROJECT_NAME}.elf verify reset exit"
+    DEPENDS ${CMAKE_PROJECT_NAME}
+  )
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(littlefs-usb
   usb_msc_driver.c
   usb_descriptors.c
   mimic_fat.c
+  unicode.c
 )
 target_link_libraries(littlefs-usb PRIVATE
   hardware_flash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,14 +6,12 @@ endif()
 include(${PICO_SDK_PATH}/external/pico_sdk_import.cmake)
 
 project(littlefs-usb C CXX ASM)
-
 set(PICO_BOARD pico_w)
 set(FAMILY rp2040)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
 
 pico_sdk_init()
-
 
 add_executable(littlefs-usb
   main.c
@@ -40,7 +38,6 @@ target_include_directories(littlefs-usb
 target_compile_options(littlefs-usb PRIVATE -Werror -Wall -Wextra -Wnull-dereference)
 target_link_options(littlefs-usb PRIVATE -Wl,--print-memory-usage)
 
-
 add_library(littlefs INTERFACE)
 target_sources(littlefs INTERFACE
   lib/littlefs/lfs.c
@@ -51,7 +48,6 @@ target_include_directories(littlefs INTERFACE
 )
 target_compile_options(littlefs INTERFACE -Wno-unused-function -Wno-null-dereference)
 target_link_libraries(littlefs INTERFACE hardware_flash)
-
 
 pico_enable_stdio_usb(littlefs-usb 1)
 pico_add_extra_outputs(littlefs-usb)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ include(${PICO_SDK_PATH}/external/pico_sdk_import.cmake)
 
 project(littlefs-usb C CXX ASM)
 
-# set(PICO_BOARD pico_w)
+set(PICO_BOARD pico_w)
 set(FAMILY rp2040)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
@@ -21,7 +21,7 @@ add_executable(littlefs-usb
   usb_descriptors.c
   mimic_fat.c
 )
-target_link_libraries(littlefs-usb
+target_link_libraries(littlefs-usb PRIVATE
   hardware_flash
   hardware_sync
   littlefs
@@ -29,6 +29,7 @@ target_link_libraries(littlefs-usb
   tinyusb_additions
   tinyusb_board
   tinyusb_device
+  pico_cyw43_arch_none
 )
 
 target_include_directories(littlefs-usb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,8 +52,6 @@ target_sources(littlefs INTERFACE
 #target_compile_options(littlefs-usb PRIVATE -Werror -Wall -Wextra -Wnull-dereference)
 string(APPEND CMAKE_EXE_LINKER_FLAGS "-Wl,--print-memory-usage")
 
-
-
 pico_enable_stdio_usb(littlefs-usb 1)
 pico_add_extra_outputs(littlefs-usb)
 
@@ -64,4 +62,6 @@ if(OPENOCD)
     COMMAND ${OPENOCD} -f interface/cmsis-dap.cfg -f target/rp2040.cfg -c "adapter speed 5000" -c "program ${CMAKE_PROJECT_NAME}.elf verify reset exit"
     DEPENDS ${CMAKE_PROJECT_NAME}
   )
+
+  add_subdirectory(tests EXCLUDE_FROM_ALL)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,20 +37,21 @@ target_include_directories(littlefs-usb
   lib/littlefs
   ${CMAKE_CURRENT_LIST_DIR}/include
 )
+target_compile_options(littlefs-usb PRIVATE -Werror -Wall -Wextra -Wnull-dereference)
+target_link_options(littlefs-usb PRIVATE -Wl,--print-memory-usage)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DPICO_USE_MALLOC_MUTEX=1")
+
 add_library(littlefs INTERFACE)
+target_sources(littlefs INTERFACE
+  lib/littlefs/lfs.c
+  lib/littlefs/lfs_util.c
+)
 target_include_directories(littlefs INTERFACE
   lib/littlefs
 )
+target_compile_options(littlefs INTERFACE -Wno-unused-function -Wno-null-dereference)
 target_link_libraries(littlefs INTERFACE hardware_flash)
-target_sources(littlefs INTERFACE
-   lib/littlefs/lfs.c
-   lib/littlefs/lfs_util.c
-)
 
-#target_compile_options(littlefs-usb PRIVATE -Werror -Wall -Wextra -Wnull-dereference)
-string(APPEND CMAKE_EXE_LINKER_FLAGS "-Wl,--print-memory-usage")
 
 pico_enable_stdio_usb(littlefs-usb 1)
 pico_add_extra_outputs(littlefs-usb)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(CMAKE_CXX_STANDARD 17)
 
 pico_sdk_init()
 
+
 add_executable(littlefs-usb
   main.c
   littlefs_driver.c
@@ -29,9 +30,7 @@ target_link_libraries(littlefs-usb PRIVATE
   tinyusb_additions
   tinyusb_board
   tinyusb_device
-  pico_cyw43_arch_none
 )
-
 target_include_directories(littlefs-usb
   PRIVATE
   lib/littlefs
@@ -51,6 +50,7 @@ target_sources(littlefs INTERFACE
 
 #target_compile_options(littlefs-usb PRIVATE -Werror -Wall -Wextra -Wnull-dereference)
 string(APPEND CMAKE_EXE_LINKER_FLAGS "-Wl,--print-memory-usage")
+
 
 
 pico_enable_stdio_usb(littlefs-usb 1)

--- a/FAT_OPERATION.md
+++ b/FAT_OPERATION.md
@@ -1,46 +1,59 @@
 # Overview of FAT file system update operations
 
-## Basic Operation
+The FAT file system is operated by operations such as updating directory entries, updating the file allocation table and sending data to the cluster. Note that the procedure for these operations differs slightly between operating systems.
 
-### Create file
+## Create
 
-1. Get a cluster that is not assigned to the FAT table
-2. Write file block to cluster
-3. Update the consumed cluster in the FAT table
-4. Add a directory entry for the file (with new cluster id)
+For macos
 
-### Update file
+1. write file blocks to unassigned clusters
+2. update File allocation table
+3. update dir entry. The clusters written in step 1 are specified
 
-1. Get a cluster that is not assigned to the FAT table
-2. Write a file block to the cluster
-3. Release assigned cluster in the FAT table, and update the consumed cluster
-4. Update the directory entry for the file (with cluster id)
+For Windows 11
 
-or, In Windows 11 do the following
+1. update dir entry. The cluster to which the file belongs is set to 0.
+2. update dir entry. The cluster to be assigned is specified. Not yet allocated.
+3. write the file block to the cluster specified in step 2.
+4. update File allocation table
 
-1. Get a cluster that is not assigned to the FAT table
-2. Release assigned cluster in the FAT table, and update the consumed cluster
-3. Update the directory entry for the file (with cluster id)
-4. Write a file block to the cluster
+## Update
 
-### delete file
+For macos
 
-1. `DIR_Name[0] = 0xE5` of the directory entry (no deletion)
-2. Release the assigned cluster from the FAT table
+1. write file blocks to unassigned clusters
+2. update File allocation table
+3. update dir entry. The cluster to which the file belongs is set to 0.
+4. update dir entry. The clusters written in step 1 are specified.
 
-### Rename
+For Windows 11
 
-Name change in the same directory. clusters do not change.
+1. update dir entry. The cluster to which the file belongs is set to 0.
+2. update File allocation table
+3. update dir entry. A new cluster is specified.
+4. write the file block to the cluster specified in step 3
+5. update File allocation table.
 
-1. Add a new file entry to the old file entry and set the delete flag (0xE5) to the old file entry.
+## Rename
 
-or, In Windows 11 do the following
+For macos
 
-1. Update new name for the target directory entry
+1. update dir entry. The old filename is flagged for deletion and a new file entry is added at the same time. Clusters have the same.
 
-### Move
+For Windows 11
 
-Moving to a different directory. clusters do not change.
+1. The file name of the directory entry is changed.
 
-1. set delete flag (0xE5) to the old file entry
-2. add new file to directory entry.
+## Move
+
+1. update the origin dir entry. Attach deletion flag to filename.
+2. add files to the destination directory entry. Clusters have the same.
+
+## Delete
+
+1. update dir entry. Assign a delete flag to the filename
+2. update File allocation table.
+
+## About Directory Entries
+
+About directory entries Directory entries are data structures that hold information on files and directories held in the file system. Each directory is assigned a unique cluster number. A directory entry holds the names and cluster numbers of the files and directories belonging to the directory.The FAT file system can scan all directories starting from the root directory. Directory entries other than the root hold the cluster number of the parent directory. Note that only references to the root directory are specified with cluster number 0.

--- a/FAT_OPERATION.md
+++ b/FAT_OPERATION.md
@@ -21,6 +21,8 @@
 1. `DIR_Name[0] = 0xE5` of the directory entry (no deletion)
 2. Release the assigned cluster from the FAT table
 
+## Rename file
+
 
 ## Sequence for macOS Connection
 

--- a/FAT_OPERATION.md
+++ b/FAT_OPERATION.md
@@ -16,8 +16,27 @@
 3. Release assigned cluster in the FAT table, and update the consumed cluster
 4. Update the directory entry for the file (with cluster id)
 
+or, In Windows 11 do the following
+
+1. Get a cluster that is not assigned to the FAT table
+2. Release assigned cluster in the FAT table, and update the consumed cluster
+3. Update the directory entry for the file (with cluster id)
+4. Write a file block to the cluster
+
 ### delete file
 
 1. `DIR_Name[0] = 0xE5` of the directory entry (no deletion)
 2. Release the assigned cluster from the FAT table
 
+### Rename
+
+Name change in the same directory. clusters do not change.
+
+1. Add a new file entry to the old file entry and set the delete flag (0xE5) to the old file entry.
+
+### Move
+
+Moving to a different directory. clusters do not change.
+
+1. set delete flag (0xE5) to the old file entry
+2. add new file to directory entry.

--- a/FAT_OPERATION.md
+++ b/FAT_OPERATION.md
@@ -34,6 +34,10 @@ Name change in the same directory. clusters do not change.
 
 1. Add a new file entry to the old file entry and set the delete flag (0xE5) to the old file entry.
 
+or, In Windows 11 do the following
+
+1. Update new name for the target directory entry
+
 ### Move
 
 Moving to a different directory. clusters do not change.

--- a/FAT_OPERATION.md
+++ b/FAT_OPERATION.md
@@ -1,0 +1,20 @@
+# Overview of FAT file system update operations
+
+## Create file
+
+1. Get a cluster that is not assigned to the FAT table
+2. Write file block to cluster
+3. Update the consumed cluster in the FAT table
+4. Add a directory entry for the file (with new cluster id)
+
+## Update file
+
+1. Get a cluster that is not assigned to the FAT table
+2. Write a file block to the cluster
+3. Release assigned cluster in the FAT table, and update the consumed cluster
+4. Update the directory entry for the file (with cluster id)
+
+## delete file
+
+1. `DIR_Name[0] = 0xE5` of the directory entry (no deletion)
+2. Release the assigned cluster from the FAT table

--- a/FAT_OPERATION.md
+++ b/FAT_OPERATION.md
@@ -21,20 +21,3 @@
 1. `DIR_Name[0] = 0xE5` of the directory entry (no deletion)
 2. Release the assigned cluster from the FAT table
 
-## Rename file
-
-
-## Sequence for macOS Connection
-
-The file ".fseventsd/fseventsd-uuid" is created.
-
-1. A buffer cleared to zero is written into the first cluster (cluster=2). The FAT table is updated to include the consumption of cluster=2.
-2. Directory entry data within ".fseventsd" is written into cluster=2.
-3. An entry for ".fseventsd" (cluster=2) is added to the root directory entry.
-4. Data for ".fseventd/fseventsd-uuid" is written into cluster=3 (name not yet assigned). The FAT table is updated to include the consumption of cluster=3.
-5. The directory entry in cluster=2 is updated to include "fseventsd-uuid" at cluster=3.
-
-Reflect the change in the root directory entry in step 3 on the local filesystem (in step 3, execute `mkdir .fseventsd`).
-Reflect the change in the subdirectory entry in step 5 on the local filesystem (in step 5, create the "fseventsd-uuid" file and write data to cluster 3).
-
-New files and directories are created using free clusters in the FAT table. This enables the transmitted anonymous buffer to be identified by its block ID (block ID -1 == cluster id), determining whether it updates an existing resource or creates a new one. Updates to existing files are performed by registering the data in a new cluster and switching the directory entry's cluster id.

--- a/FAT_OPERATION.md
+++ b/FAT_OPERATION.md
@@ -1,20 +1,38 @@
 # Overview of FAT file system update operations
 
-## Create file
+## Basic Operation
+
+### Create file
 
 1. Get a cluster that is not assigned to the FAT table
 2. Write file block to cluster
 3. Update the consumed cluster in the FAT table
 4. Add a directory entry for the file (with new cluster id)
 
-## Update file
+### Update file
 
 1. Get a cluster that is not assigned to the FAT table
 2. Write a file block to the cluster
 3. Release assigned cluster in the FAT table, and update the consumed cluster
 4. Update the directory entry for the file (with cluster id)
 
-## delete file
+### delete file
 
 1. `DIR_Name[0] = 0xE5` of the directory entry (no deletion)
 2. Release the assigned cluster from the FAT table
+
+
+## Sequence for macOS Connection
+
+The file ".fseventsd/fseventsd-uuid" is created.
+
+1. A buffer cleared to zero is written into the first cluster (cluster=2). The FAT table is updated to include the consumption of cluster=2.
+2. Directory entry data within ".fseventsd" is written into cluster=2.
+3. An entry for ".fseventsd" (cluster=2) is added to the root directory entry.
+4. Data for ".fseventd/fseventsd-uuid" is written into cluster=3 (name not yet assigned). The FAT table is updated to include the consumption of cluster=3.
+5. The directory entry in cluster=2 is updated to include "fseventsd-uuid" at cluster=3.
+
+Reflect the change in the root directory entry in step 3 on the local filesystem (in step 3, execute `mkdir .fseventsd`).
+Reflect the change in the subdirectory entry in step 5 on the local filesystem (in step 5, create the "fseventsd-uuid" file and write data to cluster 3).
+
+New files and directories are created using free clusters in the FAT table. This enables the transmitted anonymous buffer to be identified by its block ID (block ID -1 == cluster id), determining whether it updates an existing resource or creates a new one. Updates to existing files are performed by registering the data in a new cluster and switching the directory entry's cluster id.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@ Littlefs is widely used as a reliable file system for microcontrollers. However,
 The demo operates as follows:
 
 - Each time the BOOTSEL button is clicked, the number of clicks is added to the `SENSOR.TXT` file in the littlefs file system.
-- When the BOOTSEL button on the Pico is clicked for the first time, it starts as a USB stick.
 - When the Pico is connected to the host PC via USB, it will be mounted as a read-only USB flash drive with a FAT12 file system.
-- Holding down the BOOTSEL button for 10 seconds will format the littlefs file system.
+- Holding down the BOOTSEL button for 3 seconds will format the littlefs file system.
 
 ## Build and Installation
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Littlefs is widely used as a reliable file system for microcontrollers. However,
 The demo operates as follows:
 
 - Each time the BOOTSEL button is clicked, the number of clicks is added to the `SENSOR.TXT` file in the littlefs file system.
-- When the Pico is connected to the host PC via USB, it will be mounted as a read-only USB flash drive with a FAT12 file system.
+- When the Pico is connected to the host PC via USB, it will be mounted as a USB flash drive with a FAT12 file system.
+- As a USB flash drive, you can create, read, update, and delete files in littlefs. However, moving directories is not supported.
 - Holding down the BOOTSEL button for 3 seconds will format the littlefs file system.
 
 ## Build and Installation
@@ -47,6 +48,8 @@ FAT12 is a very simple file system and can be easily mimicked. Depending on the 
 - Block 3 and later: Returns littlefs file blocks or directory entries.
 
 Upon USB connection, all files in the littlefs file system are searched to build a cache of FAT directory entries. Read requests from the USB host determine the type (file or directory) of the requested object based on the cache. Requests for directories are sent directly from the cache, while requests for files open the corresponding file in littlefs and send its content. Write requests involve updating the cache and reflecting changes in littlefs. The cache is updated based on the differences in directory entries.
+
+See `FAT_OPERATION.md` for details on the sequence of disk operations.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,20 @@ FAT12 is a very simple file system and can be easily mimicked. Depending on the 
 
 Upon USB connection, all files in the littlefs file system are searched to build a cache of FAT directory entries. Read requests from the USB host determine the type (file or directory) of the requested object based on the cache. Requests for directories are sent directly from the cache, while requests for files open the corresponding file in littlefs and send its content. Write requests involve updating the cache and reflecting changes in littlefs. The cache is updated based on the differences in directory entries.
 
+## Testing
+
+The tests directory contains code to verify the API's behavior. After building and installing the test code on the Pico, the unit tests are executed directly on the device, and results are sent via UART.
+
+```bash
+make tests
+```
+
+To run the tests, transfer the `tests/tests.uf2` file to your Pico. For a more comprehensive debugging experience, connect the [Raspberry Pi Debug Probe](https://www.raspberrypi.com/documentation/microcontrollers/debug-probe.html) to the SWD Debug and UART Serial interfaces of the Pico. Use the following command to install and run the tests:
+
+```bash
+make run_tests
+```
+
 ## References
 
 - [littlefs](https://github.com/littlefs-project/littlefs)

--- a/README.md
+++ b/README.md
@@ -1,22 +1,21 @@
 # Raspberry Pi Pico littlefs USB Flash Memory Interface
 
-This project demonstrates mounting littlefs from a host PC via USB, allowing easy retrieval of accumulated sensor data and other information stored on microcontrollers from a standard PC.
+This project demonstrates a method for mounting littlefs via USB to facilitate easy retrieval of sensor data and other information stored on microcontrollers from a standard PC.
 
-Littlefs is widely used as a reliable file system for microcontrollers. However, since this file system is not supported by ordinary host PCs, special software and procedures are required for file read and write operations. The core idea of the project is to add an intermediate conversion layer on the USB Mass Storage Class device driver of the microcontroller to mimic littlefs as a FAT file system. This allows littlefs to be manipulated from the host PC as if it were a USB flash drive with a common FAT file system. Currently, only read access is available from the host PC. It may be possible to support writing as well, but it is still unclear if it can be done seamlessly.
-The only footprint added to the microcontroller is RAM that holds the first 3 blocks (3x512 bytes) of FAT12.
+Littlefs is widely used as a reliable file system for microcontrollers. However, since this file system is not supported by ordinary host PCs, special software and procedures are required for file read and write operations. The core idea of this project is to add an intermediate conversion layer to the USB Mass Storage Class device driver of the microcontroller, mimicking littlefs as a FAT file system. This allows littlefs to be manipulated from the host PC as if it were a USB flash drive with a common FAT file system.
 
-## Demonstration Overview
+## Demo Overview
 
-The demo works as follows:
+The demo operates as follows:
 
 - Each time the BOOTSEL button is clicked, the number of clicks is added to the `SENSOR.TXT` file in the littlefs file system.
-- The first time the BOOTSEL button is clicked on Pico, it starts as a USB stick.
+- When the BOOTSEL button on the Pico is clicked for the first time, it starts as a USB stick.
 - When the Pico is connected to the host PC via USB, it will be mounted as a read-only USB flash drive with a FAT12 file system.
 - Holding down the BOOTSEL button for 10 seconds will format the littlefs file system.
 
 ## Build and Installation
 
-Prepare a single Raspberry Pi Pico or Pico W, and a build environment using the [pico-sdk](https://github.com/raspberrypi/pico-sdk).
+Prepare a Raspberry Pi Pico or Pico W, and set up a build environment using the [pico-sdk](https://github.com/raspberrypi/pico-sdk).
 
 ```bash
 git submodule update --init
@@ -28,30 +27,28 @@ cmake ..
 make
 ```
 
-After successful compilation, you will have `littlefs-usb.uf2`. Simply drag and drop it onto your Raspberry Pi Pico to install and run the application.
+After successful compilation, `littlefs-usb.uf2` will be generated. Simply drag and drop it onto your Raspberry Pi Pico to install and run the application.
 
 ## Limitations
 
-Current implementation has several limitations:
+The current implementation has several limitations:
 
-- Read-only Access from USB: The USB interface supports read-only access to the littlefs.
+- Renaming a directory does not move it, but creates a new one.
 - Limited File Size: File sizes are limited due to various constraints.
-- No file update detection: The host PC cannot notice that the microcontroller has updated the file while it is mounted. Remounting will reflect the update.
-- Visibility of Root Directory Files: Only files with short filenames (8+3) placed directly in the littlefs root directory are visible from the USB side.
+- No file update detection: The host PC cannot notice when the microcontroller updates a file. Remounting will reflect the update.
 - Unrefactored Source Code: The source code has not undergone refactoring.
 
-Some limitations arise from unimplemented features, while others may not be feasible. For example, it is theoretically possible to add files unilaterally from the host PC, as in Pico's BOOTSEL mode, but a seamless implementation is not known to be feasible. Capacity constraints stem from the limited onboard flash (2MB) and the FAT12 file system (256KB). Implementing larger storage and FAT16 or FAT32 file systems would mitigate these limitations.
+## Mimicking Process
 
-## How to mimic
+FAT12 is a very simple file system and can be easily mimicked. Depending on the location of the block device requested by the USB host, the microcontroller assembles and returns the appropriate FAT12 block.
 
-FAT12 is a very simple file system and can be easily mimicked; depending on the location of the block device requested by the USB host, the microcontroller assembles and returns the appropriate FAT12 block.
+- Block 0: Returns static FAT12 boot block.
+- Block 1: Returns the file allocation table (FAT).
+- Block 2: Returns the root directory's directory entry.
+- Block 3 and later: Returns littlefs file blocks or directory entries.
 
-- Block 0: `mimic_fat_boot_sector()`. Returns static FAT12 boot block.
-- Block 1: `mimic_fat_table()`. Returns a mimicked FAT table, which searches the littlefs root directory and constructs information about the storage location on the FAT file system based on the file size of each file.
-- Block 2: `mimic_fat_root_dir_entry()`. Returns the mimicked root directory entry; searches the littlefs root directory and registers the FAT file entry.
-- Block 3 and later: `mimic_fat_file_entry()`. Returns a file block in littlefs. Searches the FAT root directory entry that holds the requested block and gets the file name and offset on littlefs. opens the file in littlefs and returns the data at the offset position.
+Upon USB connection, all files in the littlefs file system are searched to build a cache of FAT directory entries. Read requests from the USB host determine the type (file or directory) of the requested object based on the cache. Requests for directories are sent directly from the cache, while requests for files open the corresponding file in littlefs and send its content. Write requests involve updating the cache and reflecting changes in littlefs. The cache is updated based on the differences in directory entries.
 
-## Reference
+## References
 
 - [littlefs](https://github.com/littlefs-project/littlefs)
-- [TyniUSB](https://docs.tinyusb.org/en/latest/)

--- a/include/mimic_fat.h
+++ b/include/mimic_fat.h
@@ -10,6 +10,7 @@
 #include <ctype.h>
 #include <math.h>
 #include <lfs.h>
+#include "unicode.h"
 
 #define LITTLE_ENDIAN16(x) (x)
 #define LITTLE_ENDIAN32(x) (x)
@@ -48,11 +49,10 @@ enum {
 
 
 void mimic_fat_initialize_cache(void);
+void mimic_fat_cleanup_cache(void);
 void mimic_fat_boot_sector(void *buffer, uint32_t bufsize);
 void mimic_fat_table(void *buffer, uint32_t bufsize);
-
 void mimic_fat_read_cluster(uint32_t cluster, void *buffer, uint32_t bufsize);
-
 void mimic_fat_root_dir_entry(void *buffer, uint32_t bufsize);
 void mimic_fat_write(uint8_t lun, uint32_t fat_sector, uint32_t offset, void *buffer, uint32_t bufsize);
 #endif

--- a/include/mimic_fat.h
+++ b/include/mimic_fat.h
@@ -42,10 +42,8 @@ typedef struct {
     uint8_t LDIR_Name3[4];
 } fat_lfn_t;
 
-enum {
-  DISK_BLOCK_NUM  = 128,
-  DISK_BLOCK_SIZE = 512
-};
+#define DISK_BLOCK_NUM    128
+#define DISK_BLOCK_SIZE   512
 
 
 void mimic_fat_initialize_cache(void);

--- a/include/mimic_fat.h
+++ b/include/mimic_fat.h
@@ -47,9 +47,12 @@ enum {
 };
 
 
+void mimic_fat_initialize_cache(void);
 void mimic_fat_boot_sector(void *buffer, uint32_t bufsize);
 void mimic_fat_table(void *buffer, uint32_t bufsize);
+
+void mimic_fat_read_cluster(uint32_t cluster, void *buffer, uint32_t bufsize);
+
 void mimic_fat_root_dir_entry(void *buffer, uint32_t bufsize);
-void mimic_fat_file_entry(uint32_t fat_sector, void *buffer, uint32_t bufsize);
 void mimic_fat_write(uint8_t lun, uint32_t fat_sector, uint32_t offset, void *buffer, uint32_t bufsize);
 #endif

--- a/include/mimic_fat.h
+++ b/include/mimic_fat.h
@@ -42,7 +42,7 @@ typedef struct {
 } fat_lfn_t;
 
 enum {
-  DISK_BLOCK_NUM  = 16, // 8KB is the smallest size that windows allow to mount
+  DISK_BLOCK_NUM  = 128,
   DISK_BLOCK_SIZE = 512
 };
 

--- a/include/mimic_fat.h
+++ b/include/mimic_fat.h
@@ -51,5 +51,5 @@ void mimic_fat_boot_sector(void *buffer, uint32_t bufsize);
 void mimic_fat_table(void *buffer, uint32_t bufsize);
 void mimic_fat_root_dir_entry(void *buffer, uint32_t bufsize);
 void mimic_fat_file_entry(uint32_t fat_sector, void *buffer, uint32_t bufsize);
-
+void mimic_fat_write(uint8_t lun, uint32_t fat_sector, uint32_t offset, void *buffer, uint32_t bufsize);
 #endif

--- a/include/unicode.h
+++ b/include/unicode.h
@@ -5,10 +5,10 @@
 #include <stdint.h>
 
 
-size_t strlen_utf8(const uint8_t *src);
+size_t strlen_utf8(const char *src);
 size_t strlen_utf16le(const uint16_t* str, size_t size);
-size_t ascii_to_utf16le(uint16_t *dist, size_t dist_size, const uint8_t *src, size_t src_size);
-size_t utf8_to_utf16le(uint16_t *dist, size_t dist_size, const uint8_t *src, size_t src_size);
-size_t utf16le_to_utf8(uint8_t *dist, size_t buffer_size, const uint16_t *src, size_t len);
+size_t ascii_to_utf16le(uint16_t *dist, size_t dist_size, const char *src, size_t src_size);
+size_t utf8_to_utf16le(uint16_t *dist, size_t dist_size, const char *src, size_t src_size);
+size_t utf16le_to_utf8(char *dist, size_t buffer_size, const uint16_t *src, size_t len);
 
 #endif

--- a/include/unicode.h
+++ b/include/unicode.h
@@ -1,0 +1,14 @@
+#ifndef _UNICODE_H_
+#define _UNICODE_H_
+
+#include <string.h>
+#include <stdint.h>
+
+
+size_t strlen_utf8(const uint8_t *src);
+size_t strlen_utf16le(const uint16_t* str, size_t size);
+size_t ascii_to_utf16le(uint16_t *dist, size_t dist_size, const uint8_t *src, size_t src_size);
+size_t utf8_to_utf16le(uint16_t *dist, size_t dist_size, const uint8_t *src, size_t src_size);
+size_t utf16le_to_utf8(uint8_t *dist, size_t buffer_size, const uint16_t *src, size_t len);
+
+#endif

--- a/littlefs_driver.c
+++ b/littlefs_driver.c
@@ -11,7 +11,7 @@
 
 
 //#define FS_SIZE (1024 * 1024)
-#define FS_SIZE (128 * 1024)
+#define FS_SIZE (1024 * 1024)
 
 static const uint32_t fs_base = PICO_FLASH_SIZE_BYTES - FS_SIZE;
 

--- a/littlefs_driver.c
+++ b/littlefs_driver.c
@@ -10,7 +10,9 @@
 #include <lfs.h>
 
 
-#define FS_SIZE (64 * 1024)
+//#define FS_SIZE (1024 * 1024)
+#define FS_SIZE (128 * 1024)
+
 static const uint32_t fs_base = PICO_FLASH_SIZE_BYTES - FS_SIZE;
 
 

--- a/main.c
+++ b/main.c
@@ -42,8 +42,7 @@ lfs_t fs;
  * Format the file system if it does not exist
  */
 static void test_filesystem_and_format_if_necessary(bool force_format) {
-
-   if ((lfs_mount(&fs, &lfs_pico_flash_config) != 0) || force_format) {
+   if (force_format || (lfs_mount(&fs, &lfs_pico_flash_config) != 0)) {
         printf("Format the onboard flash memory with littlefs\n");
 
         lfs_unmount(&fs);

--- a/main.c
+++ b/main.c
@@ -42,12 +42,13 @@ static void test_filesystem_and_format_if_necessary(bool force_format) {
         printf("Format the onboard flash memory with littlefs\n");
 
         lfs_format(&fs, &lfs_pico_flash_config);
-
+        /*
         lfs_mount(&fs, &lfs_pico_flash_config);
         lfs_file_t f;
         lfs_file_open(&fs, &f, "README.TXT", LFS_O_RDWR|LFS_O_CREAT);
         lfs_file_write(&fs, &f, README_TXT, strlen(README_TXT));
         lfs_file_close(&fs, &f);
+        */
     }
     lfs_unmount(&fs);
 }

--- a/main.c
+++ b/main.c
@@ -42,28 +42,19 @@ lfs_t fs;
  * Format the file system if it does not exist
  */
 static void test_filesystem_and_format_if_necessary(bool force_format) {
-   lfs_unmount(&fs);
+
    if ((lfs_mount(&fs, &lfs_pico_flash_config) != 0) || force_format) {
         printf("Format the onboard flash memory with littlefs\n");
 
         lfs_unmount(&fs);
         lfs_format(&fs, &lfs_pico_flash_config);
-
         lfs_mount(&fs, &lfs_pico_flash_config);
 
         lfs_file_t f;
         lfs_file_open(&fs, &f, "README.TXT", LFS_O_RDWR|LFS_O_CREAT);
         lfs_file_write(&fs, &f, README_TXT, strlen(README_TXT));
         lfs_file_close(&fs, &f);
-
-        lfs_mkdir(&fs, "Settings");
-
-        lfs_file_t f2;
-        lfs_file_open(&fs, &f2, "Settings/wifi.txt", LFS_O_RDWR|LFS_O_CREAT);
-        lfs_file_write(&fs, &f2, "Hello World!\n", strlen("Hello World!\n"));
-        lfs_file_close(&fs, &f2);
     }
-    lfs_mount(&fs, &lfs_pico_flash_config);
 }
 
 /*
@@ -107,7 +98,7 @@ int main(void) {
     tud_init(BOARD_TUD_RHPORT);
     stdio_init_all();
 
-    test_filesystem_and_format_if_necessary(true);
+    test_filesystem_and_format_if_necessary(false);
     while (true) {
         sensor_logging_task();
         tud_task();

--- a/main.c
+++ b/main.c
@@ -50,11 +50,18 @@ static void test_filesystem_and_format_if_necessary(bool force_format) {
         lfs_format(&fs, &lfs_pico_flash_config);
 
         lfs_mount(&fs, &lfs_pico_flash_config);
+
         lfs_file_t f;
         lfs_file_open(&fs, &f, "README.TXT", LFS_O_RDWR|LFS_O_CREAT);
         lfs_file_write(&fs, &f, README_TXT, strlen(README_TXT));
         lfs_file_close(&fs, &f);
 
+        lfs_mkdir(&fs, "Settings");
+
+        lfs_file_t f2;
+        lfs_file_open(&fs, &f2, "Settings/wifi.txt", LFS_O_RDWR|LFS_O_CREAT);
+        lfs_file_write(&fs, &f2, "Hello World!\n", strlen("Hello World!\n"));
+        lfs_file_close(&fs, &f2);
     }
     lfs_mount(&fs, &lfs_pico_flash_config);
 }

--- a/main.c
+++ b/main.c
@@ -19,7 +19,6 @@
 #include "bootsel_button.h"
 
 extern const struct lfs_config lfs_pico_flash_config;  // littlefs_driver.c
-extern bool usb_device_enable;                         // usb_msc_driver.c
 
 #define FILENAME  "SENSOR.TXT"
 
@@ -77,13 +76,11 @@ static void sensor_logging_task(void) {
         lfs_file_t f;
         lfs_file_open(&fs, &f, FILENAME, LFS_O_RDWR|LFS_O_APPEND|LFS_O_CREAT);
         uint8_t buffer[512];
-        snprintf(buffer, sizeof(buffer), "click=%d\n", count);
-        lfs_file_write(&fs, &f, buffer, strlen(buffer));
-        printf(buffer);
+        snprintf((char *)buffer, sizeof(buffer), "click=%d\n", count);
+        lfs_file_write(&fs, &f, buffer, strlen((char *)buffer));
+        printf((char *)buffer);
         lfs_file_close(&fs, &f);
         lfs_unmount(&fs);
-
-        usb_device_enable = true;  // Enable USB device
     }
     last_status = button;
 

--- a/main.c
+++ b/main.c
@@ -48,13 +48,13 @@ static void test_filesystem_and_format_if_necessary(bool force_format) {
 
         lfs_unmount(&fs);
         lfs_format(&fs, &lfs_pico_flash_config);
-        /*
+
         lfs_mount(&fs, &lfs_pico_flash_config);
         lfs_file_t f;
         lfs_file_open(&fs, &f, "README.TXT", LFS_O_RDWR|LFS_O_CREAT);
         lfs_file_write(&fs, &f, README_TXT, strlen(README_TXT));
         lfs_file_close(&fs, &f);
-        */
+
     }
     lfs_mount(&fs, &lfs_pico_flash_config);
 }

--- a/main.c
+++ b/main.c
@@ -85,7 +85,7 @@ static void sensor_logging_task(void) {
     } else {
         long_push = 0;
     }
-    if (long_push > 25000) { // Long-push BOOTSEL button
+    if (long_push > 35000) { // Long-push BOOTSEL button
         test_filesystem_and_format_if_necessary(true);
         count = 0;
         long_push = 0;

--- a/mimic_fat.c
+++ b/mimic_fat.c
@@ -704,7 +704,7 @@ static int create_dir_entry_cache(unsigned char *path, uint32_t parent_cluster, 
     }
     lfs_dir_close(&real_filesystem, &dir);
     save_temporary_file(current_cluster, dir_entry);
-    print_dir_entry(dir_entry);
+    //print_dir_entry(dir_entry);
     return 0;
 }
 
@@ -817,9 +817,9 @@ static void restore_file_from(uint8_t *result_filename, uint32_t directory_clust
             break;
         }
 
-        printf("restore_file_from---\n");
-        print_dir_entry(&dir);
-        printf("--------------------\n");
+        //printf("restore_file_from---\n");
+        //print_dir_entry(&dir);
+        //printf("--------------------\n");
         uint8_t child_filename[LFS_NAME_MAX + 1];
         uint8_t filename[LFS_NAME_MAX + 1];
         uint16_t long_filename[LFS_NAME_MAX + 1];

--- a/mimic_fat.c
+++ b/mimic_fat.c
@@ -1185,6 +1185,18 @@ static void difference_of_dir_entry(fat_dir_entry_t *orig, fat_dir_entry_t *new,
                     delete++;
                     break;
                 }
+
+                if (orig[j].DIR_Attr & 0x10  // directory
+                    && new[i].DIR_FstClusLO == orig[j].DIR_FstClusLO
+                    && new[i].DIR_FileSize == 0
+                    && orig[j].DIR_Name[0] != 0xE5
+                    && i == j)
+                {
+                    // `delete` or `rename`.
+                    memcpy(delete, &orig[j], sizeof(fat_dir_entry_t));
+                    delete++;
+                    break;
+                }
             }
             continue;
         }
@@ -1539,6 +1551,7 @@ void mimic_fat_write(uint8_t lun, uint32_t request_block, uint32_t offset, void 
         memset(dir_delete , 0, sizeof(dir_delete));
         read_temporary_file(1, orig);
 
+        print_dir_entry(buffer);
         difference_of_dir_entry(&orig[0], (fat_dir_entry_t *)buffer, dir_update, dir_delete);
         delete_dir_entry_cache(dir_delete, request_block - 1);
 

--- a/mimic_fat.c
+++ b/mimic_fat.c
@@ -850,7 +850,7 @@ static void restore_file_from(uint8_t *result_filename, uint32_t directory_clust
             if (dir[i].DIR_Name[0] == 0xE5)
                 continue;
 
-            if (dir[i].DIR_Attr & 0x0F == 0x0F) {
+            if ((dir[i].DIR_Attr & 0x0F) == 0x0F) {
                 fat_lfn_t *long_file = (fat_lfn_t *)&dir[i];
                 if (long_file->LDIR_Ord & 0x40) {
                     memset(long_filename, 0xFF, sizeof(long_filename));
@@ -1006,7 +1006,7 @@ static void restore_directory_from(uint8_t *directory, uint32_t base_directory_c
             if (dir[i].DIR_Name[0] == 0xE5)
                 continue;
 
-            if (dir[i].DIR_Attr & 0x0F == 0x0F) {
+            if ((dir[i].DIR_Attr & 0x0F) == 0x0F) {
                 fat_lfn_t *long_file = (fat_lfn_t *)&dir[i];
                 if (long_file->LDIR_Ord & 0x40) {
                     memset(long_filename, 0xFF, sizeof(long_filename));

--- a/mimic_fat.c
+++ b/mimic_fat.c
@@ -711,6 +711,9 @@ void mimic_fat_initialize_cache(void) {
         printf("mimic_fat_initialize_cache: lfs_mount error=%d\n", err);
         return;
     }
+    memset(fat_table, 0, sizeof(fat_table));
+    update_fat_table(0, 0x0FF8);
+    update_fat_table(1, 0x0FFF);
 
     mimic_fat_cleanup_cache();
 

--- a/mimic_fat.c
+++ b/mimic_fat.c
@@ -19,8 +19,8 @@
 
 extern const struct lfs_config lfs_pico_flash_config;  // littlefs_driver.c
 
-static const int FAT_SHORT_NAME_MAX = 11;
-static const int FAT_LONG_FILENAME_CHUNK_MAX = 13;
+static const size_t FAT_SHORT_NAME_MAX = 11;
+static const size_t FAT_LONG_FILENAME_CHUNK_MAX = 13;
 
 static uint8_t fat_disk_image[1][DISK_BLOCK_SIZE] = {
   //------------- Block0: Boot Sector -------------//
@@ -279,7 +279,7 @@ static bool is_short_filename_dir(uint8_t *filename) {
     if (strlen((const char *)filename) > FAT_SHORT_NAME_MAX) {
         return false;
     }
-    for (int i = 0; i < FAT_SHORT_NAME_MAX; i++) {
+    for (size_t i = 0; i < FAT_SHORT_NAME_MAX; i++) {
         if (filename[i] == '\0') {
             break;
         }
@@ -1544,7 +1544,7 @@ void mimic_fat_write(uint8_t lun, uint32_t request_block, uint32_t offset, void 
         size_t offset = 0;
         uint32_t base_cluster = find_base_cluster_and_offset(request_block - 1, &offset);
         if (base_cluster == 0) {
-            //printf_debug("mimic_fat_write: not allocated cluster\n");
+            printf_debug("mimic_fat_write: not allocated cluster\n");
             save_temporary_file(request_block - 1, buffer);
 
            // For hosts that write to unallocated space first
@@ -1565,6 +1565,12 @@ void mimic_fat_write(uint8_t lun, uint32_t request_block, uint32_t offset, void 
                    base_cluster, err);
             return;
         }
+        if (err == 0) {
+            printf_debug(ANSI_RED "find_dir_entry_cache not found cluster=%lu\n" ANSI_CLEAR, base_cluster);
+            save_temporary_file(request_block - 1, buffer);
+            return;
+        }
+
         if (result.is_directory)
             update_dir_entry(request_block - 1, buffer);
         else

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(tests
   main.c
   util.c
   test_read.c
+  test_write.c
 )
 
 target_link_libraries(tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,8 +8,8 @@ add_executable(tests
   ../usb_descriptors.c
   main.c
   util.c
+  test_create.c
   test_read.c
-  test_write.c
 )
 
 target_link_libraries(tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,10 @@ add_executable(tests
   util.c
   test_create.c
   test_read.c
+  test_update.c
+  test_rename.c
+  test_move.c
+  test_delete.c
 )
 
 target_link_libraries(tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,38 @@
+set(CMAKE_BUILD_TYPE Debug)
+
+add_executable(tests
+  ../mimic_fat.c
+  ../littlefs_driver.c
+  ../unicode.c
+  ../usb_msc_driver.c
+  ../usb_descriptors.c
+  main.c
+  util.c
+  test_read.c
+)
+
+target_link_libraries(tests
+  hardware_flash
+  hardware_sync
+  littlefs
+  pico_stdlib
+  tinyusb_additions
+  tinyusb_board
+  tinyusb_device
+)
+
+target_include_directories(tests
+  PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}/../include
+)
+#target_compile_options(tests PRIVATE -Werror -Wall -Wextra -Wnull-dereference)
+pico_add_extra_outputs(tests)
+pico_enable_stdio_usb(tests 1)
+
+
+if(OPENOCD)
+  add_custom_target(run_tests
+    COMMAND ${OPENOCD} -f interface/cmsis-dap.cfg -f target/rp2040.cfg -c "adapter speed 5000" -c "program tests.elf verify reset exit"
+    DEPENDS tests
+  )
+endif()

--- a/tests/main.c
+++ b/tests/main.c
@@ -12,6 +12,10 @@ int main(void) {
 
     test_create();
     test_read();
+    test_update();
+    test_rename();
+    test_move();
+    test_delete();
 
     printf("All tests are ok\n");
 }

--- a/tests/main.c
+++ b/tests/main.c
@@ -1,0 +1,16 @@
+#include "tests.h"
+#include <bsp/board.h>
+#include <tusb.h>
+
+
+int main(void) {
+    board_init();
+    tud_init(BOARD_TUD_RHPORT);
+    stdio_init_all();
+
+    printf("Start all tests\n");
+
+    test_read();
+
+    printf("All tests are ok\n");
+}

--- a/tests/main.c
+++ b/tests/main.c
@@ -10,8 +10,8 @@ int main(void) {
 
     printf("Start all tests\n");
 
+    test_create();
     test_read();
-    test_write();
 
     printf("All tests are ok\n");
 }

--- a/tests/main.c
+++ b/tests/main.c
@@ -11,6 +11,7 @@ int main(void) {
     printf("Start all tests\n");
 
     test_read();
+    test_write();
 
     printf("All tests are ok\n");
 }

--- a/tests/test_create.c
+++ b/tests/test_create.c
@@ -25,17 +25,6 @@ static void cleanup(void) {
     lfs_unmount(&fs);
 }
 
-static void update_fat_table(uint8_t *buffer, uint16_t cluster, uint16_t value) {
-    uint16_t offset = (uint16_t)floor((float)cluster + ((float)cluster / 2)) % DISK_BLOCK_SIZE;
-    if (cluster & 0x01) {
-        buffer[offset] = (buffer[offset] & 0x0F) | (value << 4);
-        buffer[offset + 1] = value >> 4;
-    } else {
-        buffer[offset] = value;
-        buffer[offset + 1] = (buffer[offset + 1] & 0xF0) | ((value >> 8) & 0x0F);
-    }
-}
-
 static void test_create_file(void) {
     uint8_t buffer[512];
     const uint8_t message[] = "Hello World\n";
@@ -43,7 +32,7 @@ static void test_create_file(void) {
     setup();
     mimic_fat_initialize_cache();
 
-    // Update procedure from the USB layer
+    // Create procedure from the USB layer
     uint16_t cluster = 2;
     memset(buffer, 0, sizeof(buffer));
     strncpy(buffer, message, sizeof(buffer));

--- a/tests/test_delete.c
+++ b/tests/test_delete.c
@@ -9,13 +9,22 @@ static lfs_t fs;
 
 #define MESSAGE  "Please delete me!\n"
 
-static void setup(void) {
+static void setup_file(void) {
     int err = lfs_format(&fs, &lfs_pico_flash_config);
     assert(err == 0);
     err = lfs_mount(&fs, &lfs_pico_flash_config);
     assert(err == 0);
 
     create_file(&fs, "DELETEME.TXT", MESSAGE);
+}
+
+static void setup_dir(void) {
+    int err = lfs_format(&fs, &lfs_pico_flash_config);
+    assert(err == 0);
+    err = lfs_mount(&fs, &lfs_pico_flash_config);
+    assert(err == 0);
+
+    create_directory(&fs, "DIR_DEL");
 }
 
 static void reload(void) {
@@ -29,7 +38,7 @@ static void cleanup(void) {
 }
 
 static void test_delete_file(void) {
-    setup();
+    setup_file();
 
     mimic_fat_initialize_cache();
 
@@ -60,10 +69,39 @@ static void test_delete_file(void) {
     cleanup();
 }
 
+static void test_delete_dir(void) {
+    setup_dir();
+
+    mimic_fat_initialize_cache();
+
+    // Update procedure from the USB layer
+    uint16_t cluster = 2;
+    uint8_t buffer[512];
+
+    // update dir entry. Assign a delete flag to the filename
+    fat_dir_entry_t root[16] = {
+        {.DIR_Name = "littlefsUSB", .DIR_Attr = 0x08, .DIR_FstClusLO = 0, .DIR_FileSize = 0},
+        {.DIR_Name = "DIR_DEL    ", .DIR_Attr = 0x10, .DIR_FstClusLO = cluster, .DIR_FileSize = 0},
+    };
+    root[1].DIR_Name[0] = 0xE5;  // delete flag
+    tud_msc_write10_cb(0, 2, 0, root, sizeof(root));  // update directory entry
+
+    reload();
+
+    // Test reflection on the littlefs layer
+    struct lfs_info finfo;
+    int err = lfs_stat(&fs, "DIR_DEL", &finfo);
+    assert(err ==  LFS_ERR_NOENT);
+
+    cleanup();
+}
+
+
 void test_delete(void) {
     printf("delete .................");
 
     test_delete_file();
+    test_delete_dir();
 
     printf("ok\n");
 }

--- a/tests/test_move.c
+++ b/tests/test_move.c
@@ -1,0 +1,80 @@
+#include "tests.h"
+
+
+extern const struct lfs_config lfs_pico_flash_config;  // littlefs_driver.c
+extern int32_t tud_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize);
+
+static lfs_t fs;
+
+#define MESSAGE  "please move!\n"
+
+
+static void setup(void) {
+    int err = lfs_format(&fs, &lfs_pico_flash_config);
+    assert(err == 0);
+    err = lfs_mount(&fs, &lfs_pico_flash_config);
+    assert(err == 0);
+
+    create_directory(&fs, "DIR_A");
+    create_file(&fs, "MOVEME.TXT", MESSAGE);
+}
+
+static void reload(void) {
+    lfs_unmount(&fs);
+    int err = lfs_mount(&fs, &lfs_pico_flash_config);
+    assert(err == 0);
+}
+
+static void cleanup(void) {
+    lfs_unmount(&fs);
+}
+
+static void test_move_file(void) {
+    setup();
+
+    mimic_fat_initialize_cache();
+
+    // Update procedure from the USB layer
+    uint8_t buffer[512];
+
+    // update the origin dir entry. Attach deletion flag to filename.
+    fat_dir_entry_t root0[16] = {
+        {.DIR_Name = "littlefsUSB", .DIR_Attr = 0x08, .DIR_FstClusLO = 0, .DIR_FileSize = 0},
+        {.DIR_Name = "DIR_A      ", .DIR_Attr = 0x10, .DIR_FstClusLO = 2, .DIR_FileSize = 0},
+        {.DIR_Name = "MOVEME  TXT", .DIR_Attr = 0x20, .DIR_FstClusLO = 3, .DIR_FileSize = strlen(MESSAGE)},
+    };
+    root0[2].DIR_Name[0] = 0xE5;  // deletion flag
+    tud_msc_write10_cb(0, 2, 0, root0, sizeof(root0));  // update origin directory entry
+
+    fat_dir_entry_t dir_a[16] = {
+        {.DIR_Name = ".          ", .DIR_Attr = 0x10, .DIR_FstClusLO = 2, .DIR_FileSize = 0},
+        {.DIR_Name = "..         ", .DIR_Attr = 0x10, .DIR_FstClusLO = 0, .DIR_FileSize = 0},
+        {.DIR_Name = "MOVEME  TXT", .DIR_Attr = 0x20, .DIR_FstClusLO = 3, .DIR_FileSize = strlen(MESSAGE)},
+    };
+    tud_msc_write10_cb(0, 3, 0, dir_a, sizeof(dir_a));  // update destination directory entry
+
+    reload();
+
+    // Test reflection on the littlefs layer
+    lfs_file_t f;
+    int err = lfs_file_open(&fs, &f, "DIR_A/MOVEME.TXT", LFS_O_RDONLY);
+    assert(err == LFS_ERR_OK);
+    lfs_ssize_t size = lfs_file_read(&fs, &f, buffer, sizeof(buffer));
+    assert(size == strlen(MESSAGE));
+    assert(strcmp(buffer, MESSAGE) == 0);
+    lfs_file_close(&fs, &f);
+
+    struct lfs_info finfo;
+    err = lfs_stat(&fs, "MOVEME.TXT", &finfo);
+    assert(err ==  LFS_ERR_NOENT);
+
+    cleanup();
+}
+
+void test_move(void) {
+    printf("move   .................");
+
+    test_move_file();
+
+    printf("ok\n");
+}

--- a/tests/test_read.c
+++ b/tests/test_read.c
@@ -107,5 +107,6 @@ void test_read(void) {
     test_read_file();
     test_sub_directory();
     test_long_filename();
+
     printf("ok\n");
 }

--- a/tests/test_read.c
+++ b/tests/test_read.c
@@ -1,0 +1,111 @@
+#include "tests.h"
+
+
+extern const struct lfs_config lfs_pico_flash_config;  // littlefs_driver.c
+extern int32_t tud_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize);
+
+static lfs_t fs;
+
+
+static void setup(void) {
+    int err = lfs_format(&fs, &lfs_pico_flash_config);
+    assert(err == 0);
+    err = lfs_mount(&fs, &lfs_pico_flash_config);
+    assert(err == 0);
+}
+
+static void cleanup(void) {
+    lfs_unmount(&fs);
+}
+
+
+static void test_read_file(void) {
+    uint8_t buffer[512];
+
+    setup();
+
+    create_file(&fs, "TEST.TXT", "Hello World!\n");
+    mimic_fat_initialize_cache();
+
+    tud_msc_read10_cb(0, 0, 0, buffer, sizeof(buffer));  // Boot sector
+    tud_msc_read10_cb(0, 1, 0, buffer, sizeof(buffer));  // Allocation table
+    uint8_t expected_allocation_table[512] = {0xf8, 0xff, 0xff, 0xff, 0x0f, 0x00};
+    assert(memcmp(buffer, expected_allocation_table, 6) == 0);
+
+    tud_msc_read10_cb(0, 2, 0, buffer, sizeof(buffer));  // Root directory entry
+    fat_dir_entry_t root[16] = {
+        {.DIR_Name = "littlefsUSB", .DIR_Attr = 0x08, .DIR_FstClusLO = 0, .DIR_FileSize = 0},
+        {.DIR_Name = "TEST    TXT", .DIR_Attr = 0x20, .DIR_FstClusLO = 2, .DIR_FileSize = strlen("Hello World!\n")},
+    };
+    assert(dirent_cmp((fat_dir_entry_t *)buffer, root) == 0);
+
+    tud_msc_read10_cb(0, 3, 0, buffer, sizeof(buffer));  // TEST.TXT
+    assert(strcmp(buffer, "Hello World!\n") == 0);
+
+    cleanup();
+}
+
+static void test_sub_directory(void) {
+    uint8_t buffer[512];
+
+    setup();
+
+    create_directory(&fs, "DIR1");
+    create_file(&fs, "DIR1/SUB.TXT", "directory 1\n");
+    mimic_fat_initialize_cache();
+
+    tud_msc_read10_cb(0, 0, 0, buffer, sizeof(buffer));  // Boot sector
+    tud_msc_read10_cb(0, 1, 0, buffer, sizeof(buffer));  // Allocation table
+    uint8_t expected_allocation_table[512] = {0xf8, 0xff, 0xff, 0xff, 0xff, 0xFF, 0x00};
+    assert(memcmp(buffer, expected_allocation_table, 7) == 0);
+
+    tud_msc_read10_cb(0, 2, 0, buffer, sizeof(buffer));  // Root directory entry
+    fat_dir_entry_t root[16] = {
+        {.DIR_Name = "littlefsUSB", .DIR_Attr = 0x08, .DIR_FstClusLO = 0, .DIR_FileSize = 0},
+        {.DIR_Name = "DIR1       ", .DIR_Attr = 0x10, .DIR_FstClusLO = 2, .DIR_FileSize = 0},
+    };
+    assert(dirent_cmp((fat_dir_entry_t *)buffer, root) == 0);
+
+    tud_msc_read10_cb(0, 3, 0, buffer, sizeof(buffer));  // DIR1 directory entry
+    fat_dir_entry_t dir1[16] = {
+        {.DIR_Name = ".          ", .DIR_Attr = 0x10, .DIR_FstClusLO = 2, .DIR_FileSize = 0},
+        {.DIR_Name = "..         ", .DIR_Attr = 0x10, .DIR_FstClusLO = 0, .DIR_FileSize = 0},
+        {.DIR_Name = "SUB     TXT", .DIR_Attr = 0x20, .DIR_FstClusLO = 3, .DIR_FileSize = strlen("directory 1\n")},
+    };
+    assert(dirent_cmp((fat_dir_entry_t *)buffer, dir1) == 0);
+
+    tud_msc_read10_cb(0, 4, 0, buffer, sizeof(buffer));  // DIR1/SUB.TXT
+    assert(strcmp(buffer, "directory 1\n") == 0);
+
+    cleanup();
+}
+
+static void test_long_filename(void) {
+    uint8_t buffer[512];
+
+    setup();
+
+    create_file(&fs, "over 8x3 long filename.TXT", "long file name\n");
+    mimic_fat_initialize_cache();
+
+    tud_msc_read10_cb(0, 2, 0, buffer, sizeof(buffer));  // Root directory entry
+
+    fat_dir_entry_t root[16] = {
+        {.DIR_Name = "littlefsUSB", .DIR_Attr = 0x08, .DIR_FstClusLO = 0, .DIR_FileSize = 0},
+        {},
+        {},
+        {.DIR_Name = "FIL~4000TXT", .DIR_Attr = 0x20, .DIR_FstClusLO = 2, .DIR_FileSize = strlen("long file name\n")},
+    };
+    set_long_filename_entry((fat_lfn_t *)&root[1], " filename.TXT", 0x42);
+    set_long_filename_entry((fat_lfn_t *)&root[2], "over 8x3 long", 0x01);
+    assert(dirent_cmp_lfn((fat_dir_entry_t *)buffer, root) == 0);
+}
+
+void test_read(void) {
+    printf("read ...................");
+
+    test_read_file();
+    test_sub_directory();
+    test_long_filename();
+    printf("ok\n");
+}

--- a/tests/test_rename.c
+++ b/tests/test_rename.c
@@ -1,0 +1,110 @@
+#include "tests.h"
+
+
+extern const struct lfs_config lfs_pico_flash_config;  // littlefs_driver.c
+extern int32_t tud_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize);
+extern int32_t tud_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize);
+
+static lfs_t fs;
+
+#define MESSAGE  "please rename!\n"
+
+
+static void setup(void) {
+    int err = lfs_format(&fs, &lfs_pico_flash_config);
+    assert(err == 0);
+    err = lfs_mount(&fs, &lfs_pico_flash_config);
+    assert(err == 0);
+
+    create_file(&fs, "ORIGINAL.TXT", MESSAGE);
+}
+
+static void reload(void) {
+    lfs_unmount(&fs);
+    int err = lfs_mount(&fs, &lfs_pico_flash_config);
+    assert(err == 0);
+}
+
+static void cleanup(void) {
+    lfs_unmount(&fs);
+}
+
+static void test_rename_file(void) {
+    setup();
+
+    mimic_fat_initialize_cache();
+
+    // Update procedure from the USB layer
+    uint8_t buffer[512];
+    uint16_t cluster = 2;
+
+    // update dir entry. The old filename is flagged for deletion and a new file entry
+    // is added at the same time. Clusters have the same.
+    fat_dir_entry_t root0[16] = {
+        {.DIR_Name = "littlefsUSB", .DIR_Attr = 0x08, .DIR_FstClusLO = 0, .DIR_FileSize = 0},
+        {.DIR_Name = "ORIGINALTXT", .DIR_Attr = 0x20, .DIR_FstClusLO = 2, .DIR_FileSize = strlen(MESSAGE)},
+        {.DIR_Name = "RENAMED TXT", .DIR_Attr = 0x20, .DIR_FstClusLO = 2, .DIR_FileSize = strlen(MESSAGE)},
+    };
+    root0[1].DIR_Name[0] = 0xE5;
+    tud_msc_write10_cb(0, 2, 0, root0, sizeof(root0));  // update directory entry
+
+    reload();
+
+    // Test reflection on the littlefs layer
+    lfs_file_t f;
+    int err = lfs_file_open(&fs, &f, "RENAMED.TXT", LFS_O_RDONLY);
+    assert(err == LFS_ERR_OK);
+    lfs_ssize_t size = lfs_file_read(&fs, &f, buffer, sizeof(buffer));
+    assert(size == strlen(MESSAGE));
+    assert(strcmp(buffer, MESSAGE) == 0);
+    lfs_file_close(&fs, &f);
+
+    struct lfs_info finfo;
+    err = lfs_stat(&fs, "ORIGINAL.TXT", &finfo);
+    assert(err ==  LFS_ERR_NOENT);
+
+    cleanup();
+}
+
+static void test_rename_file_windows11(void) {
+    setup();
+
+    mimic_fat_initialize_cache();
+
+    // Update procedure from the USB layer
+    uint8_t buffer[512];
+    uint16_t cluster = 2;
+
+    //  The file name of the directory entry is changed.
+    fat_dir_entry_t root0[16] = {
+        {.DIR_Name = "littlefsUSB", .DIR_Attr = 0x08, .DIR_FstClusLO = 0, .DIR_FileSize = 0},
+        {.DIR_Name = "RENAMED TXT", .DIR_Attr = 0x20, .DIR_FstClusLO = 2, .DIR_FileSize = strlen(MESSAGE)},
+    };
+    tud_msc_write10_cb(0, 2, 0, root0, sizeof(root0));  // update directory entry
+
+    reload();
+
+    // Test reflection on the littlefs layer
+    lfs_file_t f;
+    int err = lfs_file_open(&fs, &f, "RENAMED.TXT", LFS_O_RDONLY);
+    assert(err == LFS_ERR_OK);
+    lfs_ssize_t size = lfs_file_read(&fs, &f, buffer, sizeof(buffer));
+    assert(size == strlen(MESSAGE));
+    assert(strcmp(buffer, MESSAGE) == 0);
+    lfs_file_close(&fs, &f);
+
+    struct lfs_info finfo;
+    err = lfs_stat(&fs, "ORIGINAL.TXT", &finfo);
+    assert(err ==  LFS_ERR_NOENT);
+
+    cleanup();
+}
+
+void test_rename(void) {
+    printf("rename .................");
+
+    test_rename_file();
+    test_rename_file_windows11();
+
+    printf("ok\n");
+}

--- a/tests/test_update.c
+++ b/tests/test_update.c
@@ -1,0 +1,136 @@
+#include "tests.h"
+
+
+extern const struct lfs_config lfs_pico_flash_config;  // littlefs_driver.c
+extern int32_t tud_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize);
+extern int32_t tud_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize);
+
+static lfs_t fs;
+
+
+static void setup(void) {
+    int err = lfs_format(&fs, &lfs_pico_flash_config);
+    assert(err == 0);
+    err = lfs_mount(&fs, &lfs_pico_flash_config);
+    assert(err == 0);
+
+    create_file(&fs, "UPDATE.TXT", "Please update!\n");
+}
+
+static void reload(void) {
+    lfs_unmount(&fs);
+    int err = lfs_mount(&fs, &lfs_pico_flash_config);
+    assert(err == 0);
+}
+
+static void cleanup(void) {
+    lfs_unmount(&fs);
+}
+
+static void test_update_file(void) {
+    setup();
+
+    mimic_fat_initialize_cache();
+
+    // Update procedure from the USB layer
+    uint16_t cluster = 3;  // unassigned cluster
+    uint8_t buffer[512];
+    const uint8_t message[] = "Hello World!\n";
+    // write file blocks to unassigned clusters
+    memset(buffer, 0, sizeof(buffer));
+    strncpy(buffer, message, sizeof(buffer));
+    tud_msc_write10_cb(0, cluster + 1, 0, buffer, sizeof(buffer));  // write to anonymous cache
+
+    // update File allocation table
+    uint8_t fat_table[512] = {0xF8, 0xFF, 0xFF, 0xFF, 0x0F};  // With cluster 2 allocated
+    update_fat_table(fat_table, cluster, 0xFFF);
+    tud_msc_write10_cb(0, 1, 0, fat_table, sizeof(fat_table));  // update file allocated table
+
+    // update dir entry. The cluster to which the file belongs is set to 0.
+    fat_dir_entry_t root0[16] = {
+        {.DIR_Name = "littlefsUSB", .DIR_Attr = 0x08, .DIR_FstClusLO = 0, .DIR_FileSize = 0},
+        {.DIR_Name = "UPDATE  TXT", .DIR_Attr = 0x20, .DIR_FstClusLO = 0, .DIR_FileSize = 0},
+    };
+    tud_msc_write10_cb(0, 2, 0, root0, sizeof(root0));  // update directory entry
+
+    // update dir entry. The clusters written in step 1 are specified.
+    fat_dir_entry_t root1[16] = {
+        {.DIR_Name = "littlefsUSB", .DIR_Attr = 0x08, .DIR_FstClusLO = 0, .DIR_FileSize = 0},
+        {.DIR_Name = "UPDATE  TXT", .DIR_Attr = 0x20, .DIR_FstClusLO = cluster, .DIR_FileSize = strlen(message)},
+    };
+    tud_msc_write10_cb(0, 2, 0, root1, sizeof(root1));  // update directory entry
+
+    reload();
+
+    // Test reflection on the littlefs layer
+    lfs_file_t f;
+    int err = lfs_file_open(&fs, &f, "UPDATE.TXT", LFS_O_RDONLY);
+    assert(err == LFS_ERR_OK);
+    lfs_ssize_t size = lfs_file_read(&fs, &f, buffer, sizeof(buffer));
+    assert(size == strlen(message));
+    assert(strcmp(buffer, message) == 0);
+    lfs_file_close(&fs, &f);
+
+    cleanup();
+}
+
+static void test_update_file_windows11(void) {
+    setup();
+
+    mimic_fat_initialize_cache();
+
+    // Update procedure from the USB layer
+    uint16_t cluster = 3;  // unassigned cluster
+    uint8_t buffer[512];
+    const uint8_t message[] = "Hello World!\n";
+
+    // update dir entry. The cluster to which the file belongs is set to 0.
+    fat_dir_entry_t root0[16] = {
+        {.DIR_Name = "littlefsUSB", .DIR_Attr = 0x08, .DIR_FstClusLO = 0, .DIR_FileSize = 0},
+        {.DIR_Name = "UPDATE  TXT", .DIR_Attr = 0x20, .DIR_FstClusLO = 0, .DIR_FileSize = 0},
+    };
+    tud_msc_write10_cb(0, 2, 0, root0, sizeof(root0));  // update directory entry
+
+    // update File allocation table
+    uint8_t fat_table[512] = {0xF8, 0xFF, 0xFF, 0xFF, 0x0F};  // With cluster 2 allocated
+    update_fat_table(fat_table, cluster, 0xFFF);
+    tud_msc_write10_cb(0, 1, 0, fat_table, sizeof(fat_table));  // update file allocated table
+
+    // update dir entry. The clusters written in step 2 are specified.
+    fat_dir_entry_t root1[16] = {
+        {.DIR_Name = "littlefsUSB", .DIR_Attr = 0x08, .DIR_FstClusLO = 0, .DIR_FileSize = 0},
+        {.DIR_Name = "UPDATE  TXT", .DIR_Attr = 0x20, .DIR_FstClusLO = cluster, .DIR_FileSize = strlen(message)},
+    };
+    tud_msc_write10_cb(0, 2, 0, root1, sizeof(root1));  // update directory entry
+
+    // write the file block to the cluster specified in step 3
+    memset(buffer, 0, sizeof(buffer));
+    strncpy(buffer, message, sizeof(buffer));
+    tud_msc_write10_cb(0, cluster + 1, 0, buffer, sizeof(buffer));
+
+    // update File allocation table
+    update_fat_table(fat_table, 2, 0x000);  // Release old allocated areas
+    tud_msc_write10_cb(0, 1, 0, fat_table, sizeof(fat_table));  // update file allocated table
+
+    reload();
+
+    // Test reflection on the littlefs layer
+    lfs_file_t f;
+    int err = lfs_file_open(&fs, &f, "UPDATE.TXT", LFS_O_RDONLY);
+    assert(err == LFS_ERR_OK);
+    lfs_ssize_t size = lfs_file_read(&fs, &f, buffer, sizeof(buffer));
+    assert(size == strlen(message));
+    assert(strcmp(buffer, message) == 0);
+    lfs_file_close(&fs, &f);
+
+    cleanup();
+}
+
+void test_update(void) {
+    printf("update .................");
+
+    test_update_file();
+    test_update_file_windows11();
+
+    printf("ok\n");
+}

--- a/tests/test_update.c
+++ b/tests/test_update.c
@@ -2,7 +2,6 @@
 
 
 extern const struct lfs_config lfs_pico_flash_config;  // littlefs_driver.c
-extern int32_t tud_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize);
 extern int32_t tud_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize);
 
 static lfs_t fs;

--- a/tests/test_write.c
+++ b/tests/test_write.c
@@ -1,0 +1,127 @@
+#include "tests.h"
+
+
+extern const struct lfs_config lfs_pico_flash_config;  // littlefs_driver.c
+extern int32_t tud_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize);
+extern int32_t tud_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize);
+
+static lfs_t fs;
+
+
+static void setup(void) {
+    int err = lfs_format(&fs, &lfs_pico_flash_config);
+    assert(err == 0);
+    err = lfs_mount(&fs, &lfs_pico_flash_config);
+    assert(err == 0);
+}
+
+static void reload(void) {
+    lfs_unmount(&fs);
+    int err = lfs_mount(&fs, &lfs_pico_flash_config);
+    assert(err == 0);
+}
+
+static void cleanup(void) {
+    lfs_unmount(&fs);
+}
+
+static void update_fat_table(uint8_t *buffer, uint16_t cluster, uint16_t value) {
+    uint16_t offset = (uint16_t)floor((float)cluster + ((float)cluster / 2)) % DISK_BLOCK_SIZE;
+    if (cluster & 0x01) {
+        buffer[offset] = (buffer[offset] & 0x0F) | (value << 4);
+        buffer[offset + 1] = value >> 4;
+    } else {
+        buffer[offset] = value;
+        buffer[offset + 1] = (buffer[offset + 1] & 0xF0) | ((value >> 8) & 0x0F);
+    }
+}
+
+static void test_create_file(void) {
+    uint8_t buffer[512];
+    const uint8_t message[] = "Hello World\n";
+
+    setup();
+    mimic_fat_initialize_cache();
+
+    // Update procedure from the USB layer
+    uint16_t cluster = 2;
+    memset(buffer, 0, sizeof(buffer));
+    strncpy(buffer, message, sizeof(buffer));
+    tud_msc_write10_cb(0, cluster + 1, 0, buffer, sizeof(buffer));  // write to anonymous cache
+
+    uint8_t fat_table[512] = {0xF8, 0xFF, 0xFF, 0x00, 0x00};
+    update_fat_table(fat_table, cluster, 0xFFF);
+    tud_msc_write10_cb(0, 1, 0, fat_table, sizeof(fat_table));  // update file allocated table
+
+    fat_dir_entry_t root[16] = {
+        {.DIR_Name = "littlefsUSB", .DIR_Attr = 0x08, .DIR_FstClusLO = 0, .DIR_FileSize = 0},
+        {.DIR_Name = "TEST    TXT", .DIR_Attr = 0x20, .DIR_FstClusLO = cluster, .DIR_FileSize = strlen(message)},
+    };
+    tud_msc_write10_cb(0, 2, 0, root, sizeof(root));  // update directory entry
+
+    reload();
+
+    // Test reflection on the littlefs layer
+    lfs_file_t f;
+    int err = lfs_file_open(&fs, &f, "TEST.TXT", LFS_O_RDONLY);
+    assert(err == LFS_ERR_OK);
+    lfs_ssize_t size = lfs_file_read(&fs, &f, buffer, sizeof(buffer));
+    assert(size == strlen(message));
+    assert(strcmp(buffer, message) == 0);
+    lfs_file_close(&fs, &f);
+
+    cleanup();
+}
+
+static void test_create_accross_blocksize(void) {
+    uint8_t buffer[512];
+    uint8_t read_buffer[1024];
+    const uint8_t message[] = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n" \
+                              "Hello World\n";  //512 byte + "Hello World\n"
+
+    setup();
+    mimic_fat_initialize_cache();
+
+    // Update procedure from the USB layer
+    uint16_t cluster = 2;
+    memcpy(buffer, message, sizeof(buffer));
+    tud_msc_write10_cb(0, cluster + 1, 0, buffer, sizeof(buffer));  // write to first block
+    memset(buffer, 0, sizeof(buffer));
+    strncpy(buffer, message + 512, sizeof(buffer));
+    tud_msc_write10_cb(0, cluster + 2, 0, buffer, sizeof(buffer));  // write to 2nd block
+
+    uint8_t fat_table[512] = {0xF8, 0xFF, 0xFF, 0x00, 0x00};
+    update_fat_table(fat_table, cluster, cluster + 1);  // point next cluster
+    update_fat_table(fat_table, cluster + 1, 0xFFF);  // terminate allocate chain
+    tud_msc_write10_cb(0, 1, 0, fat_table, sizeof(fat_table));  // update file allocated table
+
+    fat_dir_entry_t root[16] = {
+        {.DIR_Name = "littlefsUSB", .DIR_Attr = 0x08, .DIR_FstClusLO = 0, .DIR_FileSize = 0},
+        {.DIR_Name = "TEST    TXT", .DIR_Attr = 0x20, .DIR_FstClusLO = cluster, .DIR_FileSize = strlen(message)},
+    };
+    tud_msc_write10_cb(0, 2, 0, root, sizeof(root));  // update directory entry
+
+    reload();
+
+    // Test reflection on the littlefs layer
+    lfs_file_t f;
+    int err = lfs_file_open(&fs, &f, "TEST.TXT", LFS_O_RDONLY);
+    assert(err == LFS_ERR_OK);
+    lfs_ssize_t size = lfs_file_read(&fs, &f, read_buffer, sizeof(read_buffer));
+    assert(size == strlen(message));
+    assert(strcmp(read_buffer, message) == 0);
+    lfs_file_close(&fs, &f);
+
+    cleanup();
+}
+
+
+void test_write(void) {
+    printf("write ..................");
+
+    test_create_file();
+    test_create_accross_blocksize();
+    //test_update_file();
+
+    printf("ok\n");
+}

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -17,6 +17,7 @@
 extern const uint32_t FLASH_BASE;
 
 void test_read(void);
+void test_write(void);
 
 void print_block(uint8_t *buffer, size_t l);
 void print_dir_entry(void *buffer);

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -18,13 +18,18 @@ extern const uint32_t FLASH_BASE;
 
 void test_create(void);
 void test_read(void);
-
+void test_update(void);
+void test_rename(void);
+void test_move(void);
+void test_delete(void);
 
 void print_block(uint8_t *buffer, size_t l);
 void print_dir_entry(void *buffer);
 
 void create_file(lfs_t *fs, const unsigned char *path, const unsigned char *content);
 void create_directory(lfs_t *fs, const unsigned char *path);
+void update_fat_table(uint8_t *buffer, uint16_t cluster, uint16_t value);
+
 int dirent_cmp(fat_dir_entry_t *a, fat_dir_entry_t *b);
 int dirent_cmp_lfn(fat_dir_entry_t *a, fat_dir_entry_t *b);
 void set_long_filename_entry(fat_lfn_t *ent, uint8_t *name, uint8_t order);

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -16,8 +16,9 @@
 
 extern const uint32_t FLASH_BASE;
 
+void test_create(void);
 void test_read(void);
-void test_write(void);
+
 
 void print_block(uint8_t *buffer, size_t l);
 void print_dir_entry(void *buffer);

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024, Hiroyuki OYAMA. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef _TESTS_H_
+#define _TESTS_H_
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pico/stdlib.h>
+#include <lfs.h>
+#include "mimic_fat.h"
+
+
+extern const uint32_t FLASH_BASE;
+
+void test_read(void);
+
+void print_block(uint8_t *buffer, size_t l);
+void print_dir_entry(void *buffer);
+
+void create_file(lfs_t *fs, const unsigned char *path, const unsigned char *content);
+void create_directory(lfs_t *fs, const unsigned char *path);
+int dirent_cmp(fat_dir_entry_t *a, fat_dir_entry_t *b);
+int dirent_cmp_lfn(fat_dir_entry_t *a, fat_dir_entry_t *b);
+void set_long_filename_entry(fat_lfn_t *ent, uint8_t *name, uint8_t order);
+
+#endif
+

--- a/tests/util.c
+++ b/tests/util.c
@@ -56,6 +56,16 @@ void print_dir_entry(void *buffer) {
     }
 }
 
+void update_fat_table(uint8_t *buffer, uint16_t cluster, uint16_t value) {
+    uint16_t offset = (uint16_t)floor((float)cluster + ((float)cluster / 2)) % DISK_BLOCK_SIZE;
+    if (cluster & 0x01) {
+        buffer[offset] = (buffer[offset] & 0x0F) | (value << 4);
+        buffer[offset + 1] = value >> 4;
+    } else {
+        buffer[offset] = value;
+        buffer[offset + 1] = (buffer[offset + 1] & 0xF0) | ((value >> 8) & 0x0F);
+    }
+}
 
 void create_file(lfs_t *fs, const unsigned char *path, const unsigned char *content) {
     lfs_file_t f;

--- a/tests/util.c
+++ b/tests/util.c
@@ -1,0 +1,158 @@
+#include "tests.h"
+
+
+static const int FAT_SHORT_NAME_MAX = 11;
+static const int FAT_SHORT_8x3_MAX = 8 + 3 + 1;
+static const int FAT_LONG_FILENAME_CHUNK_MAX = 13;
+
+
+void print_block(uint8_t *buffer, size_t l) {
+    for (size_t i = 0; i < l; ++i) {
+        if (isalnum(buffer[i])) {
+            printf("'%c' ", buffer[i]);
+        } else {
+            printf("0x%02x", buffer[i]);
+        }
+        if (i % 16 == 15)
+            printf("\n");
+        else
+            printf(", ");
+    }
+}
+
+void print_dir_entry(void *buffer) {
+    uint8_t pbuffer[11+1];
+    fat_dir_entry_t *dir = (fat_dir_entry_t *)buffer;
+    printf("--------\n");
+    for (int i = 0; i < DISK_BLOCK_SIZE / sizeof(fat_dir_entry_t); i++) {
+        if (dir->DIR_Name[0] == '\0') {
+            break;
+        }
+        if ((dir->DIR_Attr & 0x0F) != 0x0F) {
+            memcpy(pbuffer, &dir->DIR_Name, 11);
+            pbuffer[11] = '\0';
+            printf("name='%s' attr=0x%02X timeTenth=%u, CrtDate=%u,%u"
+                   " writeDateTime=%u,%u LstAccDate=%u Size=%u cluster=%u\n",
+                   pbuffer,
+                   dir->DIR_Attr,
+                   dir->DIR_CrtTimeTenth,
+                   dir->DIR_CrtDate, dir->DIR_CrtTime,
+                   dir->DIR_WrtDate, dir->DIR_WrtTime,
+                   dir->DIR_LstAccDate,
+                   dir->DIR_FileSize,
+                   dir->DIR_FstClusLO);
+        } else {
+            fat_lfn_t *lfn = (fat_lfn_t *)dir;
+            uint16_t utf16le[13 + 1];
+            memcpy(utf16le, lfn->LDIR_Name1, 5*2);
+            memcpy(utf16le + 5, lfn->LDIR_Name2, 6*2);
+            memcpy(utf16le + 5 + 6, lfn->LDIR_Name3, 2*2);
+            utf16le[13] = '\0';
+            uint8_t utf8[13 * 4 + 1];
+            utf16le_to_utf8(utf8, sizeof(utf8), utf16le, 13);
+            printf("name='%s' attr=0x%02X ord=0x%02X cluster=%u\n", utf8, lfn->LDIR_Attr, lfn->LDIR_Ord, dir->DIR_FstClusLO);
+        }
+        dir++;
+    }
+}
+
+
+void create_file(lfs_t *fs, const unsigned char *path, const unsigned char *content) {
+    lfs_file_t f;
+    int err = lfs_file_open(fs, &f, path, LFS_O_RDWR|LFS_O_CREAT);
+    assert(err == 0);
+    size_t size = lfs_file_write(fs, &f, content, strlen(content));
+    assert(size == strlen(content));
+    lfs_file_close(fs, &f);
+}
+
+void create_directory(lfs_t *fs, const unsigned char *path) {
+    int err = lfs_mkdir(fs, path);
+    assert(err == 0);
+}
+
+void set_long_filename_entry(fat_lfn_t *ent, uint8_t *name, uint8_t order) {
+    ent->LDIR_Ord = order;
+    ent->LDIR_Attr = 0x0F;
+    ent->LDIR_Name1;
+
+    uint16_t chunk[13];
+    size_t l = utf8_to_utf16le(chunk, sizeof(chunk), name, 13);
+    memcpy(ent->LDIR_Name1, chunk + 0, sizeof(uint16_t) * 5);
+    memcpy(ent->LDIR_Name2, chunk + 5, sizeof(uint16_t) * 6);
+    memcpy(ent->LDIR_Name3, chunk + 5 + 6, sizeof(uint16_t) * 2);
+    for (int i = 0; i < 5*2; i += 2) {
+        if (ent->LDIR_Name1[i] == 0x00 && ent->LDIR_Name1[i+1] == 0x00) {
+            ent->LDIR_Name1[i] = 0xFF;
+            ent->LDIR_Name1[i+1] = 0xFF;
+        }
+    }
+    for (int i = 0; i < 6*2; i += 2) {
+        if (ent->LDIR_Name2[i] == 0x00 && ent->LDIR_Name2[i+1] == 0x00) {
+            ent->LDIR_Name2[i] = 0xFF;
+            ent->LDIR_Name2[i+1] = 0xFF;
+        }
+    }
+    for (int i = 0; i < 2*2; i += 2) {
+        if (ent->LDIR_Name3[i] == 0x00 && ent->LDIR_Name3[i+1] == 0x00) {
+            ent->LDIR_Name3[i] = 0xFF;
+            ent->LDIR_Name3[i+1] = 0xFF;
+        }
+    }
+    if (l < 13 && l < 5) {
+        ent->LDIR_Name1[l * 2]     = 0x00;
+        ent->LDIR_Name1[l * 2 + 1] = 0x00;
+    } else if (l < FAT_LONG_FILENAME_CHUNK_MAX && l < FAT_SHORT_NAME_MAX) {
+        ent->LDIR_Name2[(l-5) * 2]     = 0x00;
+        ent->LDIR_Name2[(l-5) * 2 + 1] = 0x00;
+    } else if (l < FAT_LONG_FILENAME_CHUNK_MAX) {
+        ent->LDIR_Name3[(l-5-6) * 2]     = 0x00;
+        ent->LDIR_Name3[(l-5-6) * 2 + 1] = 0x00;
+    }
+}
+
+int dirent_cmp(fat_dir_entry_t *a, fat_dir_entry_t *b) {
+    for (int i = 0; i < 16; i++) {
+        if (memcmp((a + i)->DIR_Name, (b + i)->DIR_Name, 11) != 0)
+            return -1;
+        if ((a + i)->DIR_Attr != (b + i)->DIR_Attr)
+            return -1;
+        if ((a + i)->DIR_FstClusLO != (b + i)->DIR_FstClusLO)
+            return -1;
+        if ((a + i)->DIR_FileSize != (b + i)->DIR_FileSize)
+            return -1;
+    }
+    return 0;
+}
+
+int dirent_cmp_lfn(fat_dir_entry_t *a, fat_dir_entry_t *b) {
+    bool is_long = false;
+    for (int i = 0; i < 16; i++) {
+        if ((a + i)->DIR_Attr == 0x0F) {
+            fat_lfn_t *al = (fat_lfn_t *)(a + i);
+            fat_lfn_t *bl = (fat_lfn_t *)(b + i);
+            if (memcmp(al->LDIR_Name1, bl->LDIR_Name1, sizeof(uint16_t) * 5) != 0)
+                return -1;
+            if (memcmp(al->LDIR_Name2, bl->LDIR_Name2, sizeof(uint16_t) * 6) != 0)
+                return -1;
+            if (memcmp(al->LDIR_Name3, bl->LDIR_Name3, sizeof(uint16_t) * 2) != 0)
+                return -1;
+            if (al->LDIR_Attr != bl->LDIR_Attr)
+                return -1;
+            if (al->LDIR_Ord != bl->LDIR_Ord)
+                return -1;
+            is_long = true;
+        } else {
+            if (is_long == false && memcmp((a + i)->DIR_Name, (b + i)->DIR_Name, 11) != 0)
+                return -1;
+            if ((a + i)->DIR_Attr != (b + i)->DIR_Attr)
+                return -1;
+            if ((a + i)->DIR_FstClusLO != (b + i)->DIR_FstClusLO)
+                return -1;
+            if ((a + i)->DIR_FileSize != (b + i)->DIR_FileSize)
+                return -1;
+            is_long = false;
+        }
+    }
+    return 0;
+}

--- a/unicode.c
+++ b/unicode.c
@@ -1,0 +1,170 @@
+#include "unicode.h"
+
+
+size_t strlen_utf8(const uint8_t *src) {
+    size_t count = 0;
+    size_t i = 0;
+    size_t src_size = strlen(src);
+
+    while (i < src_size) {
+        uint8_t byte = src[i];
+
+        if ((byte & 0x80) == 0) {  // 1-byte UTF-8
+            count++;
+        } else if ((byte & 0xE0) == 0xC0) {  // 2-byte UTF-8
+            count++;
+            i++;  // Skip the continuation byte
+        } else if ((byte & 0xF0) == 0xE0) {  // 3-byte UTF-8
+            count++;
+            i += 2;  // Skip the continuation bytes
+        } else if ((byte & 0xF8) == 0xF0) {  // 4-byte UTF-8
+            count++;
+            i += 3;  // Skip the continuation bytes
+        } else {
+            return -1;  // Invalid UTF-8 byte
+        }
+
+        i++;
+    }
+    return count;
+}
+
+size_t strlen_utf16le(const uint16_t* str, size_t size) {
+    size_t length = 0;
+
+    while (length <size && str[length] != 0) {
+        length++;
+    }
+
+    return length;
+}
+
+
+size_t ascii_to_utf16le(uint16_t *dist, size_t dist_size, const uint8_t *src, size_t src_size) {
+    size_t utf16le_pos = 0;
+
+    for (size_t i = 0; i < src_size && src[i] != '\0'; ++i) {
+        uint32_t codepoint = (uint32_t)src[i];
+
+        if (utf16le_pos + 1 <= dist_size) {
+            dist[utf16le_pos++] = (uint16_t)codepoint;
+        } else {
+            break;
+        }
+    }
+
+    if (utf16le_pos < dist_size) {
+        dist[utf16le_pos] = '\0';
+    }
+    return utf16le_pos;
+}
+
+// Convert UTF-8 to UTF-16LE and return the length of the converted string
+size_t utf8_to_utf16le(uint16_t* dist, size_t dist_size, const uint8_t* src, size_t src_size) {
+    size_t dist_pos = 0;
+    size_t src_pos = 0;
+
+    while (src_pos < src_size && dist_pos < dist_size) {
+        uint32_t codepoint = 0;
+        size_t extra_bytes = 0;
+
+        uint8_t byte = src[src_pos];
+
+        // Determine the number of bytes for the UTF-8 codepoint
+        if ((byte & 0x80) == 0) {  // 1-byte UTF-8
+            codepoint = byte;
+        } else if ((byte & 0xE0) == 0xC0) {  // 2-byte UTF-8
+            codepoint = byte & 0x1F;
+            extra_bytes = 1;
+        } else if ((byte & 0xF0) == 0xE0) {  // 3-byte UTF-8
+            codepoint = byte & 0x0F;
+            extra_bytes = 2;
+        } else if ((byte & 0xF8) == 0xF0) {  // 4-byte UTF-8
+            codepoint = byte & 0x07;
+            extra_bytes = 3;
+        } else {
+            // Invalid UTF-8 byte
+            return -1;  // Return -1 to indicate an error
+        }
+
+        // Calculate the complete codepoint
+        for (size_t j = 0; j < extra_bytes; ++j) {
+            src_pos++;
+            if (src_pos >= src_size) {
+                return -1;  // Incomplete UTF-8 sequence
+            }
+
+            byte = src[src_pos];
+            if ((byte & 0xC0) != 0x80) {
+                return -1;  // Invalid UTF-8 continuation byte
+            }
+
+            codepoint = (codepoint << 6) | (byte & 0x3F);
+        }
+
+        // Convert to UTF-16LE
+        if (codepoint <= 0xFFFF) {  // Basic Multilingual Plane
+            if (dist_pos < dist_size) {
+                dist[dist_pos++] = (uint16_t)codepoint;
+            }
+        } else {  // Supplementary Planes (surrogates)
+            codepoint -= 0x10000;
+            if (dist_pos + 1 < dist_size) {
+                dist[dist_pos++] = 0xD800 | ((codepoint >> 10) & 0x3FF);
+                dist[dist_pos++] = 0xDC00 | (codepoint & 0x3FF);
+                dist_pos += 2;
+            } else {
+                return -1;  // Not enough space for surrogates
+            }
+        }
+
+        src_pos++;
+    }
+
+    if (dist_pos < dist_size) {
+        dist[dist_pos] = 0;  // Null-terminate
+    }
+
+    return dist_pos;
+}
+
+size_t utf16le_to_utf8(uint8_t *dist, size_t buffer_size, const uint16_t *src, size_t len) {
+    size_t dist_len = 0;
+
+    for (size_t i = 0; i < len; ++i) {
+        uint32_t codepoint = src[i];
+        if (codepoint == 0xFFFF) {
+            break;
+        }
+
+        if (codepoint <= 0x7F) {
+            if (dist_len + 1 <= buffer_size) {
+                dist[dist_len++] = (uint8_t)codepoint;
+            } else {
+                break;
+            }
+        } else if (codepoint <= 0x7FF) {
+            if (dist_len + 2 <= buffer_size) {
+                dist[dist_len++] = (uint8_t)(0xC0 | (codepoint >> 6));
+                dist[dist_len++] = (uint8_t)(0x80 | (codepoint & 0x3F));
+            } else {
+                break;
+            }
+        } else if (codepoint <= 0xFFFF) {
+            if (dist_len + 3 <= buffer_size) {
+                dist[dist_len++] = (uint8_t)(0xE0 | (codepoint >> 12));
+                dist[dist_len++] = (uint8_t)(0x80 | ((codepoint >> 6) & 0x3F));
+                dist[dist_len++] = (uint8_t)(0x80 | (codepoint & 0x3F));
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+
+    if (dist_len < buffer_size) {
+        dist[dist_len] = '\0';
+    }
+    return dist_len;
+}

--- a/unicode.c
+++ b/unicode.c
@@ -1,7 +1,7 @@
 #include "unicode.h"
 
 
-size_t strlen_utf8(const uint8_t *src) {
+size_t strlen_utf8(const char *src) {
     size_t count = 0;
     size_t i = 0;
     size_t src_size = strlen(src);
@@ -29,7 +29,7 @@ size_t strlen_utf8(const uint8_t *src) {
     return count;
 }
 
-size_t strlen_utf16le(const uint16_t* str, size_t size) {
+size_t strlen_utf16le(const uint16_t *str, size_t size) {
     size_t length = 0;
 
     while (length <size && str[length] != 0) {
@@ -40,7 +40,7 @@ size_t strlen_utf16le(const uint16_t* str, size_t size) {
 }
 
 
-size_t ascii_to_utf16le(uint16_t *dist, size_t dist_size, const uint8_t *src, size_t src_size) {
+size_t ascii_to_utf16le(uint16_t *dist, size_t dist_size, const char *src, size_t src_size) {
     size_t utf16le_pos = 0;
 
     for (size_t i = 0; i < src_size && src[i] != '\0'; ++i) {
@@ -60,7 +60,7 @@ size_t ascii_to_utf16le(uint16_t *dist, size_t dist_size, const uint8_t *src, si
 }
 
 // Convert UTF-8 to UTF-16LE and return the length of the converted string
-size_t utf8_to_utf16le(uint16_t* dist, size_t dist_size, const uint8_t* src, size_t src_size) {
+size_t utf8_to_utf16le(uint16_t* dist, size_t dist_size, const char *src, size_t src_size) {
     size_t dist_pos = 0;
     size_t src_pos = 0;
 
@@ -128,7 +128,7 @@ size_t utf8_to_utf16le(uint16_t* dist, size_t dist_size, const uint8_t* src, siz
     return dist_pos;
 }
 
-size_t utf16le_to_utf8(uint8_t *dist, size_t buffer_size, const uint16_t *src, size_t len) {
+size_t utf16le_to_utf8(char *dist, size_t buffer_size, const uint16_t *src, size_t len) {
     size_t dist_len = 0;
 
     for (size_t i = 0; i < len; ++i) {

--- a/usb_msc_driver.c
+++ b/usb_msc_driver.c
@@ -9,7 +9,7 @@
 
 
 static bool ejected = false;
-bool usb_device_enable = false;
+bool usb_device_enable = true;
 
 
 void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16], uint8_t product_rev[4]) {
@@ -25,6 +25,8 @@ void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16
 }
 
 bool tud_msc_test_unit_ready_cb(uint8_t lun) {
+    (void)lun;
+
     return usb_device_enable;
 }
 
@@ -51,7 +53,9 @@ bool tud_msc_start_stop_cb(uint8_t lun, uint8_t power_condition, bool start, boo
 }
 
 int32_t tud_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize) {
-    (void) lun;
+    (void)lun;
+    (void)offset;
+
     if ( lba >= DISK_BLOCK_NUM ) return -1;
 
     if (lba == 0) { // read Boot sector

--- a/usb_msc_driver.c
+++ b/usb_msc_driver.c
@@ -118,3 +118,7 @@ void tud_mount_cb(void) {
   printf("\e[45mmount\n\e[0m");
   mimic_fat_initialize_cache();
 }
+
+void tud_umount_cb(void) {
+  printf("\e[45munmount\n\e[0m");
+}

--- a/usb_msc_driver.c
+++ b/usb_msc_driver.c
@@ -71,7 +71,7 @@ int32_t tud_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buff
 
 bool tud_msc_is_writable_cb (uint8_t lun) {
     (void) lun;
-    return false; // READ ONLY
+    return true;
 }
 
 int32_t tud_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset, uint8_t* buffer, uint32_t bufsize) {
@@ -80,7 +80,7 @@ int32_t tud_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset, uint8_t* 
 
     // out of ramdisk
     if ( lba >= DISK_BLOCK_NUM ) return -1;
-
+    mimic_fat_write(lun, lba, offset, buffer, bufsize);
     return (int32_t) bufsize;
 }
 

--- a/usb_msc_driver.c
+++ b/usb_msc_driver.c
@@ -72,7 +72,7 @@ int32_t tud_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buff
 
 bool tud_msc_is_writable_cb (uint8_t lun) {
     (void) lun;
-    return false;
+    return true;
 }
 
 int32_t tud_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset, uint8_t* buffer, uint32_t bufsize) {

--- a/usb_msc_driver.c
+++ b/usb_msc_driver.c
@@ -64,18 +64,15 @@ int32_t tud_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buff
     } else if (lba == 1) {  // read FAT table
         mimic_fat_table(buffer, bufsize);
         return (int32_t)bufsize;
-    } else if (lba == 2) { // read Root dir entry
-        mimic_fat_root_dir_entry(buffer, bufsize);
-        return (int32_t)bufsize;
-    } else { // data entry
-        mimic_fat_file_entry(lba, buffer, bufsize);
+    } else { // root dir entry or other cluster
+        mimic_fat_read_cluster(lba - 1, buffer, bufsize);
         return (int32_t)bufsize;
     }
 }
 
 bool tud_msc_is_writable_cb (uint8_t lun) {
     (void) lun;
-    return true;
+    return false;
 }
 
 int32_t tud_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset, uint8_t* buffer, uint32_t bufsize) {
@@ -115,4 +112,9 @@ int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16], void* buffer, 
         }
     }
     return (int32_t)resplen;
+}
+
+void tud_mount_cb(void) {
+  printf("\e[45mmount\n\e[0m");
+  mimic_fat_initialize_cache();
 }

--- a/usb_msc_driver.c
+++ b/usb_msc_driver.c
@@ -115,11 +115,13 @@ int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16], void* buffer, 
 }
 
 void tud_mount_cb(void) {
-    printf("\e[45mmount\n\e[0m");
+    printf("\e[45mmount\e[0m\n");
     mimic_fat_initialize_cache();
 }
 
-void tud_umount_cb(void) {
-    printf("\e[45munmount\n\e[0m");
+void tud_suspend_cb(bool remote_wakeup_en) {
+    (void)remote_wakeup_en;
+
+    printf("\e[45msuspend\e[0m\n");
     mimic_fat_cleanup_cache();
 }

--- a/usb_msc_driver.c
+++ b/usb_msc_driver.c
@@ -115,10 +115,11 @@ int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16], void* buffer, 
 }
 
 void tud_mount_cb(void) {
-  printf("\e[45mmount\n\e[0m");
-  mimic_fat_initialize_cache();
+    printf("\e[45mmount\n\e[0m");
+    mimic_fat_initialize_cache();
 }
 
 void tud_umount_cb(void) {
-  printf("\e[45munmount\n\e[0m");
+    printf("\e[45munmount\n\e[0m");
+    mimic_fat_cleanup_cache();
 }


### PR DESCRIPTION
#5

- [x] File name mapping process when writing to USB
- [x] USB host request for directory creation
- [x] Reflect file updates from USB host to littlefs (Long file name)
- [x] Short file name restoration
- [x] Read/Write consistency maintenance on FAT image
- [x] Address differences in file update procedures between macos and windows 11
- [x] Delete all cache files beforehand when mounting USB
- [x] Unit test
- [x] Switching log output
- [x] Bug in which multiple writes to a cluster not assigned to a file are misidentified as directory entries.
- [x] Delete directory
